### PR TITLE
Add agentskill.sh to learn more section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ The @agent-team-configurator automatically sets up your perfect AI development t
 
 ## 📚 Learn More
 
-- [Creating Custom Agents](docs/creating-agents.md) - Build specialists for your needs  
+- [Creating Custom Agents](docs/creating-agents.md) - Build specialists for your needs
 - [Best Practices](docs/best-practices.md) - Get the most from your AI team
+- [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, and 20+ AI tools
 
 ## 💬 Join The Community
 


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Learn More section.

agentskill.sh is a directory of 69,000+ AI agent skills with one-click install for Claude Code, Cursor, Copilot, Windsurf, and 20+ AI tools.