### PR TITLE
Add ORCH — CLI orchestrator for AI agent teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ MIT License - Use freely in your projects!
 [![Star History Chart](https://api.star-history.com/svg?repos=vijaythecoder/awesome-claude-agents&type=Date)](https://www.star-history.com/#vijaythecoder/awesome-claude-agents&Date)
 ---
 
+## 🔗 Related Orchestration Tools
+
+Tools that complement or extend Claude agent workflows:
+
+- [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime for orchestrating AI agent teams (Claude Code, Codex, Cursor). State machine, auto-retry, messaging, goals, TUI. 1647 tests. MIT TypeScript.
+
+
 <p align="center">
   <strong>Transform Claude Code into an AI development team that ships production-ready features</strong><br>
   <em>Simple setup. Powerful results. Just describe and build.</em>


### PR DESCRIPTION
## Summary

Adds a new **Related Orchestration Tools** section to the README with [ORCH](https://github.com/oxgeneral/ORCH) as the first entry.

**Why ORCH fits here:**

This repo is about orchestrating Claude Code agent teams. ORCH is the CLI runtime that manages exactly that — it coordinates multiple AI agents (Claude Code, Codex, Cursor) with a state machine, auto-retry, inter-agent messaging, and a TUI dashboard.

**ORCH entry:**

> [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime for orchestrating AI agent teams (Claude Code, Codex, Cursor). State machine, auto-retry, messaging, goals, TUI. 1647 tests. MIT TypeScript.

**Key features:**
- State machine: `todo → in_progress → review → done` with mandatory review gate
- Auto-retry for failed agents
- Inter-agent messaging (`orch msg send/broadcast`)
- Goal → task hierarchy
- Team structure with named roles
- Programmatic npm API (`@oxgeneral/orch`)
- TUI dashboard (Ink/React)

ORCH is a natural complement to awesome-claude-agents: users who set up a team of specialized agents here can use ORCH to orchestrate and manage those teams in production workflows.