### PR TITLE
Add Skillfold to Learn More section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The @agent-team-configurator automatically sets up your perfect AI development t
 
 - [Creating Custom Agents](docs/creating-agents.md) - Build specialists for your needs  
 - [Best Practices](docs/best-practices.md) - Get the most from your AI team
+- [Skillfold](https://github.com/byronxlg/skillfold) - Configuration language and compiler for multi-agent AI pipelines. Compiles a single YAML config into agent skills for 11 platforms including Claude Code, Cursor, Copilot, and Gemini.
 
 ## 💬 Join The Community
 


### PR DESCRIPTION
**[architect]**

## Description

Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Learn More section.

Skillfold is a configuration language and compiler for multi-agent AI pipelines. It compiles a single YAML config into agent skills for 12 platforms including Claude Code, Cursor, Copilot, Gemini, Codex, Windsurf, Goose, Roo Code, Kiro, and Junie. MIT licensed.

## Type of Change
- [ ] New agent
- [ ] Bug fix
- [ ] Enhancement
- [x] Documentation update

## Checklist
- [x] No sensitive information included
- [x] Follows existing format in Learn More section