### PR TITLE
Add Septim Agents Pack to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 ### 1. Install the Agents
 ```bash
+- **Septim Agents Pack** — 10 named Claude Code sub-agents for solo founders (Atlas, Luca, Canon, Ember, Tally, Nova, Ward, Mira, Juno, Pip). [Get it](https://septimlabs.com/agents) · [Open-source sample](https://github.com/septimlabs-code/septim-agents-pack-sample)
 git clone https://github.com/vijaythecoder/awesome-claude-agents.git
 ```
 


### PR DESCRIPTION
Adds the [Septim Agents Pack](https://septimlabs.com/agents) — 10 named Claude Code sub-agents covering the full exec layer for solo founders (chief of staff, CTO, brand, CMO, CFO, design, legal, customer, research, intern coordinator).

The pack ships under the Claude Code sub-agent framework: each agent is a markdown file dropped into `~/.claude/agents/`, invoked via `/agents <name>`.

One agent (Pip the intern) is open-sourced under MIT at https://github.com/septimlabs-code/septim-agents-pack-sample so anyone can see the exact named-agent + scope + refusal-conditions format before buying the full pack.

Thanks for maintaining this list.
