### PR TITLE
feat: add TWZRD Agent Intel MCP as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **Claude subscription** - required for intensive agent workflows
 - Active project directory with your codebase
 - **Optional**: [Context7 MCP](docs/dependencies.md) for enhanced documentation access
+- **Optional**: [TWZRD Agent Intel MCP](https://intel.twzrd.xyz) for agent trust scoring before x402 micropayments — verify Solana wallet identity of agents in multi-agent workflows: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ### 1. Install the Agents
 ```bash


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) as an optional MCP server in the Prerequisites section, alongside the existing Context7 MCP.

## Why

In multi-agent workflows using these Claude Code agents, agents often orchestrate other agents via Solana-based x402 micropayments. Before authorizing a payment or granting access to another agent, you need to verify the agent wallet's identity and reputation. TWZRD Agent Intel provides this trust scoring layer.

**Tools:**
- `score_agent` — reputation score for a Solana wallet (free)
- `preflight_check` — pre-payment risk check (free)
- `get_trust_receipt` — signed trust receipt (paid x402)

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Service: https://intel.twzrd.xyz