### PR TITLE
Add Vexilo field guide to Learn More

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The @agent-team-configurator automatically sets up your perfect AI development t
 
 - [Creating Custom Agents](docs/creating-agents.md) - Build specialists for your needs  
 - [Best Practices](docs/best-practices.md) - Get the most from your AI team
+- [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) — Visual interactive index of 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow. One-click "Teach Claude this handbook" feeds the whole index into a local session in 30s. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 
 ## 💬 Join The Community
 


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to the Learn More section

[Vexilo](https://vexilo.app/?lang=en) is a visual interactive index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click **"Teach Claude this handbook"** feeds the whole index into a local Claude session in 30 seconds.

### Why it fits
- Complementary to your awesome-claude-agents collection (you ship 24 agents; Vexilo indexes them alongside 7 other toolkits)
- Fills the "Learn More" gap (currently only points to your own docs)
- Zero install, browser-based

### Checklist
- [x] Open and free
- [x] Actively maintained (v1.1.9)
- [x] Directly relevant
- [x] Companion repo MIT-licensed